### PR TITLE
fix memory leak in packp.readRef()

### DIFF
--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -248,7 +248,10 @@ func readRef(data []byte) (string, plumbing.Hash, error) {
 	case len(chunks) > 2:
 		return "", plumbing.ZeroHash, fmt.Errorf("malformed ref data: more than one space found")
 	default:
-		return string(chunks[1]), plumbing.NewHash(string(chunks[0])), nil
+		var ref, hash []byte
+		copy(ref, chunks[1])
+		copy(hash, chunks[0])
+		return string(ref), plumbing.NewHash(string(hash)), nil
 	}
 }
 


### PR DESCRIPTION
Copy slice contents into variables instead of returning the element by referring to the index. This allows for the slice to be cleaned up by the GC.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>