### PR TITLE
initialize slices in packp.readRefs() with a fixed size

### DIFF
--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -248,7 +248,8 @@ func readRef(data []byte) (string, plumbing.Hash, error) {
 	case len(chunks) > 2:
 		return "", plumbing.ZeroHash, fmt.Errorf("malformed ref data: more than one space found")
 	default:
-		var ref, hash []byte
+		ref := make([]byte, len(chunks[1]))
+		hash := make([]byte, len(chunks[0]))
 		copy(ref, chunks[1])
 		copy(hash, chunks[0])
 		return string(ref), plumbing.NewHash(string(hash)), nil


### PR DESCRIPTION
Fix regression introduced in 28b82b9, which tried to fix a memory leak by copying slice elements into standalone vars, but doesn't work since copy() only copies until the array's length.

Signed-off-by: Sanskar Jaiswal <jaiswalsanskar078@gmail.com>