### PR TITLE
Undo auto-populate HostKeyAlgorithms

### DIFF
--- a/plumbing/protocol/packp/advrefs_decode.go
+++ b/plumbing/protocol/packp/advrefs_decode.go
@@ -248,10 +248,7 @@ func readRef(data []byte) (string, plumbing.Hash, error) {
 	case len(chunks) > 2:
 		return "", plumbing.ZeroHash, fmt.Errorf("malformed ref data: more than one space found")
 	default:
-		var ref, hash []byte
-		copy(ref, chunks[1])
-		copy(hash, chunks[0])
-		return string(ref), plumbing.NewHash(string(hash)), nil
+		return string(chunks[1]), plumbing.NewHash(string(chunks[0])), nil
 	}
 }
 

--- a/plumbing/transport/ssh/common.go
+++ b/plumbing/transport/ssh/common.go
@@ -122,10 +122,17 @@ func (c *command) connect() error {
 		return err
 	}
 	hostWithPort := c.getHostWithPort()
-	config, err = SetConfigHostKeyFields(config, hostWithPort)
-	if err != nil {
-		return err
-	}
+
+	//TODO: Fix auto-populate HostKeyAlgorithms upstream so the below can be uncommented.
+	// The introduction of auto-populate HostKeyAlgorithms in Go-Git breaks Flux implementation
+	// as it relies on file-based knownhosts. Flux injects in-memory knownhosts instead.
+	//
+	// https://github.com/go-git/go-git/pull/548
+	// https://github.com/fluxcd/pkg/blob/b37a57c5f1439eb9fe38d5f5f1af96ac17633513/ssh/knownhosts/knownhosts.go#L370
+	// config, err = SetConfigHostKeyFields(config, hostWithPort)
+	// if err != nil {
+	// 	return err
+	// }
 
 	overrideConfig(c.config, config)
 


### PR DESCRIPTION
The introduction of auto-populate HostKeyAlgorithms in Go-Git breaks Flux implementation as it relies on file-based knownhosts. Flux injects in-memory knownhosts instead.

Reverts #1 due to a regression that was introduced as part of that change.