### PR TITLE
Enable `multi_ack` and `multi_ack_detailed` capabilities

### DIFF
--- a/plumbing/protocol/packp/srvresp.go
+++ b/plumbing/protocol/packp/srvresp.go
@@ -21,11 +21,6 @@ type ServerResponse struct {
 // Decode decodes the response into the struct, isMultiACK should be true, if
 // the request was done with multi_ack or multi_ack_detailed capabilities.
 func (r *ServerResponse) Decode(reader *bufio.Reader, isMultiACK bool) error {
-	// TODO: implement support for multi_ack or multi_ack_detailed responses
-	if isMultiACK {
-		return errors.New("multi_ack and multi_ack_detailed are not supported")
-	}
-
 	s := pktline.NewScanner(reader)
 
 	for s.Scan() {

--- a/plumbing/protocol/packp/srvresp_test.go
+++ b/plumbing/protocol/packp/srvresp_test.go
@@ -75,5 +75,5 @@ func (s *ServerResponseSuite) TestDecodeMalformed(c *C) {
 func (s *ServerResponseSuite) TestDecodeMultiACK(c *C) {
 	sr := &ServerResponse{}
 	err := sr.Decode(bufio.NewReader(bytes.NewBuffer(nil)), true)
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }

--- a/plumbing/protocol/packp/uppackresp_test.go
+++ b/plumbing/protocol/packp/uppackresp_test.go
@@ -67,7 +67,7 @@ func (s *UploadPackResponseSuite) TestDecodeMultiACK(c *C) {
 	defer res.Close()
 
 	err := res.Decode(ioutil.NopCloser(bytes.NewBuffer(nil)))
-	c.Assert(err, NotNil)
+	c.Assert(err, IsNil)
 }
 
 func (s *UploadPackResponseSuite) TestReadNoDecode(c *C) {

--- a/plumbing/transport/common.go
+++ b/plumbing/transport/common.go
@@ -268,8 +268,6 @@ func parseFile(endpoint string) (*Endpoint, bool) {
 // UnsupportedCapabilities are the capabilities not supported by any client
 // implementation
 var UnsupportedCapabilities = []capability.Capability{
-	capability.MultiACK,
-	capability.MultiACKDetailed,
 	capability.ThinPack,
 }
 

--- a/plumbing/transport/common_test.go
+++ b/plumbing/transport/common_test.go
@@ -184,5 +184,5 @@ func (s *SuiteCommon) TestFilterUnsupportedCapabilities(c *C) {
 	l.Set(capability.MultiACK)
 
 	FilterUnsupportedCapabilities(l)
-	c.Assert(l.Supports(capability.MultiACK), Equals, false)
+	c.Assert(l.Supports(capability.MultiACK), Equals, true)
 }

--- a/plumbing/transport/test/upload_pack.go
+++ b/plumbing/transport/test/upload_pack.go
@@ -1,6 +1,5 @@
 // Package test implements common test suite for different transport
 // implementations.
-//
 package test
 
 import (
@@ -88,7 +87,7 @@ func (s *UploadPackSuite) TestAdvertisedReferencesFilterUnsupported(c *C) {
 
 	info, err := r.AdvertisedReferences()
 	c.Assert(err, IsNil)
-	c.Assert(info.Capabilities.Supports(capability.MultiACK), Equals, false)
+	c.Assert(info.Capabilities.Supports(capability.MultiACK), Equals, true)
 }
 
 func (s *UploadPackSuite) TestCapabilities(c *C) {


### PR DESCRIPTION
Enabling `multi_ack` and `multi_ack_detailed` allows the use of `go-git` against Azure DevOps.
**Those capabilities are not fully implemented**, however they have no impact for "fresh new fetches", which are the primary use case for Flux.

:warning: Using this version to deal with existing repositories or to call additional `fetch`/`pull` operations against Azure DevOps will result in:
```
empty git-upload-pack given
```

This change was tested against a range of Git Service Providers to ensure no regression was being introduced.
Note that the tests were completed on the scope of Source and Image Automation Controllers, which only use a subset of the Git features implemented by `go-git`.
```
https-aws-codecommit
https-bitbucket
https-devops-flux-testing
https-gitlab
https-google-code
ssh-ecdsa-bitbucket
ssh-ecdsa-gitlab
ssh-ecdsa-google
ssh-ed25519-bitbucket
ssh-ed25519-gitlab
ssh-ed25519-google
ssh-rsa-aws-codecommit
ssh-rsa-bitbucket
ssh-rsa-devops
ssh-rsa-gitlab
ssh-rsa-google
```

The blue line in the graph below represents `rate(go_memstats_alloc_bytes_total{app="source-controller"}[$__rate_interval])` and shows a stable memory profile throughout the 6h. The same has been observed since the beginning of the tests (+19h).
![image](https://user-images.githubusercontent.com/5452977/196413026-808d7ece-4870-4ab1-ad90-901cf999fb43.png)


For the purposes of the tests, all the repositories had their `spec.gitImplementation` set to `go-git`, the controller has its libgit2 managed transport disabled and `OptimizedGitClones=false`. The controller was set to have 40 workers to quickly iterate through the 35 GitRepository objects. Most target sources have at least one large file (~100mb). The reconciliation intervals are set to `30s`, forcing the reconciliations to be overlapping every so often.

Additional memory and GC related settings:
```yaml
      - op: replace
        path: /spec/template/spec/containers/0/resources/limits/memory
        value: 1200Mi
      - op: replace
        path: /spec/template/spec/containers/0/resources/requests/memory
        value: 1200Mi
      - op: add
        path: /spec/template/spec/containers/0/env/0
        value:
          name: GOMEMLIMIT
          value: "800MiB"
     - op: add
        path: /spec/template/spec/containers/0/env/0
        value:
          name: GOGC
          value: "100"
```

For completeness, an additional graph without `go_memstats_alloc_bytes_total` so it is easier to track GC duration and goroutine numbers:
![image](https://user-images.githubusercontent.com/5452977/196413106-d8f0a41a-9ea8-4eee-ab88-1eb62129fca2.png)
