### PR TITLE
Return error instead of creating empty commits

### DIFF
--- a/worktree_commit.go
+++ b/worktree_commit.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"errors"
 	"path"
 	"sort"
 	"strings"
@@ -14,6 +15,12 @@ import (
 
 	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/go-git/go-billy/v5"
+)
+
+var (
+	// ErrEmptyCommit occurs when a commit is attempted using a clean
+	// working tree, with no changes to be committed.
+	ErrEmptyCommit = errors.New("cannot create empty commit: clean working tree")
 )
 
 // Commit stores the current contents of the index in a new commit along with
@@ -146,6 +153,10 @@ type buildTreeHelper struct {
 // BuildTree builds the tree objects and push its to the storer, the hash
 // of the root tree is returned.
 func (h *buildTreeHelper) BuildTree(idx *index.Index) (plumbing.Hash, error) {
+	if len(idx.Entries) == 0 {
+		return plumbing.ZeroHash, ErrEmptyCommit
+	}
+
 	const rootNode = ""
 	h.trees = map[string]*object.Tree{rootNode: {}}
 	h.entries = map[string]*object.TreeEntry{}

--- a/worktree_commit_test.go
+++ b/worktree_commit_test.go
@@ -26,10 +26,16 @@ import (
 )
 
 func (s *WorktreeSuite) TestCommitEmptyOptions(c *C) {
-	r, err := Init(memory.NewStorage(), memfs.New())
+	fs := memfs.New()
+	r, err := Init(memory.NewStorage(), fs)
 	c.Assert(err, IsNil)
 
 	w, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	util.WriteFile(fs, "foo", []byte("foo"), 0644)
+
+	_, err = w.Add("foo")
 	c.Assert(err, IsNil)
 
 	hash, err := w.Commit("foo", &CommitOptions{})
@@ -63,6 +69,18 @@ func (s *WorktreeSuite) TestCommitInitial(c *C) {
 	c.Assert(err, IsNil)
 
 	assertStorageStatus(c, r, 1, 1, 1, expected)
+}
+
+func (s *WorktreeSuite) TestNothingToCommit(c *C) {
+	r, err := Init(memory.NewStorage(), memfs.New())
+	c.Assert(err, IsNil)
+
+	w, err := r.Worktree()
+	c.Assert(err, IsNil)
+
+	hash, err := w.Commit("empty commit\n", &CommitOptions{Author: defaultSignature()})
+	c.Assert(hash, Equals, plumbing.ZeroHash)
+	c.Assert(err, Equals, ErrEmptyCommit)
 }
 
 func (s *WorktreeSuite) TestCommitParent(c *C) {


### PR DESCRIPTION
BuildTree now returns an `ErrEmptyCommit` error, when there are no changes to be committed.

This is a breaking change which enables applications to detect when empty commits are to be created.

Some instances in which this can occur is when the fs (e.g. `billy/osfs`) make changes to the underlying files, causing a conflict between what the previous Git worktree state was, and the current state. Changes to the fs implementations are orthogonal to this, and will be dealt with separately.

The new behaviour aligns with the Git CLI, in which empty commits returns the error message: `nothing to commit, working tree clean`.